### PR TITLE
Fixed port in server.js.

### DIFF
--- a/build/gulp-tasks/server.js
+++ b/build/gulp-tasks/server.js
@@ -6,7 +6,8 @@
 module.exports = (gulp, $, options) => {
 
     const paths = require('../gulp-config/paths');
-    const { port, ui } = options.hosts.development;
+    const { ui } = options.hosts.development;
+    const port = options.hosts.development.ports.connect || 8000;
 
     const serverConfigDefault = {
         notify: false,


### PR DESCRIPTION
Object in hosts.js does not have a single 'port' property.
This was causing dev task to throw error trying to connect
to localhost:undefined

Also, I added a default to 8000 to avoid this issue to happen when no port is set in hosts.js