### PR TITLE
Refactor notification logic

### DIFF
--- a/build/gulp-tasks/fonts.js
+++ b/build/gulp-tasks/fonts.js
@@ -3,17 +3,19 @@
  * ===============================
  */
 
+const { getNotifier } = require('./lib/plugins');
+
 module.exports = (gulp, $, options) => () => {
     const paths = require('../gulp-config/paths');
     const destFolder = paths.toPath('dist.assets/fonts');
     const filesMatch = '**/*.{eot,svg,ttf,woff,woff2}';
 
-    const { isWatching, enableNotify } = options;
+    const { notify } = getNotifier(options);
 
     return gulp.src([paths.toPath(`src.assets/fonts/${filesMatch}`)])
         .pipe($.changed(destFolder))
         .pipe(gulp.dest(destFolder))
-        .pipe($.if(isWatching && enableNotify, $.notify({ message: 'Fonts synced', onLast: true })))
+        .pipe(notify({ message: 'Fonts synced', onLast: true }))
         .pipe($.size({ title: 'fonts' }));
 
 };

--- a/build/gulp-tasks/images.js
+++ b/build/gulp-tasks/images.js
@@ -3,12 +3,14 @@
  * ===============================
  */
 const paths = require('../gulp-config/paths');
+const { getNotifier } = require('./lib/plugins');
 
 module.exports = (gulp, $, options) => () => {
     const destPath = paths.toPath('dist.assets/images');
     const filesMatch = '**/*.{png,jpg,gif,svg,webp}';
     const plugins = [];
-    const { production, isWatching, enableNotify } = options;
+    const { production } = options;
+    const { notify } = getNotifier(options);
 
     plugins.push($.imagemin.svgo({
         plugins: [
@@ -31,7 +33,7 @@ module.exports = (gulp, $, options) => () => {
         .pipe(gulp.dest(destPath))
         .pipe($.if(production, $.rev.manifest({ merge: true, path: paths.toPath('dist.root/dist.revmap') })))
         .pipe($.if(production, gulp.dest('.')))
-        .pipe($.if(isWatching && enableNotify, $.notify({ message: 'Images Processed', onLast: true })))
+        .pipe(notify({ message: 'Images Processed', onLast: true }))
         .pipe($.size({ title: 'images' }));
 
 };

--- a/build/gulp-tasks/lib/plugins.js
+++ b/build/gulp-tasks/lib/plugins.js
@@ -4,8 +4,9 @@
 
 const through = require('through2');
 const PluginError = require('plugin-error');
+const notify = require('gulp-notify');
 
-module.exports.map = function map(fn) {
+const map = function map(fn) {
 
     const mapFn = typeof fn === 'function' ? fn : (val) => val;
 
@@ -32,4 +33,34 @@ module.exports.map = function map(fn) {
 
         cb();
     });
+};
+
+const noop = () => through.obj();
+
+let reloadStream;
+const getReloadStream = ({ isWatching, livereload, buildHash }) => {
+    if (isWatching && livereload) {
+        return reloadStream || (reloadStream = require('browser-sync').get(buildHash).stream); //eslint-disable-line no-return-assign
+    }
+    return noop;
+};
+
+const getNotifier = ({ isWatching, enableNotify }) => {
+    if (isWatching && enableNotify) {
+        return {
+            notify,
+            errorHandler: notify.onError('Error: <%= error.message %>')
+        };
+    }
+    return {
+        notify: noop,
+        errorHandler: true
+    };
+};
+
+module.exports = {
+    map,
+    noop,
+    getReloadStream,
+    getNotifier
 };

--- a/build/gulp-tasks/media.js
+++ b/build/gulp-tasks/media.js
@@ -4,16 +4,17 @@
  */
 
 const paths = require('../gulp-config/paths');
+const { getNotifier } = require('./lib/plugins');
 
 module.exports = (gulp, $, options) => () => {
 
     const distPath = paths.toPath('dist.assets/media');
-    const { isWatching, enableNotify } = options;
+    const { notify } = getNotifier(options);
 
     return gulp.src(paths.toPath('src.assets/media/**/*.*'))
         .pipe($.changed(distPath))
         .pipe(gulp.dest(distPath))
-        .pipe($.if(isWatching && enableNotify, $.notify({ message: 'Media files synced', onLast: true })))
+        .pipe(notify({ message: 'Media files synced', onLast: true }))
         .pipe($.size({ title: 'media' }));
 
 };

--- a/build/gulp-tasks/scripts.js
+++ b/build/gulp-tasks/scripts.js
@@ -8,18 +8,18 @@ const paths = require('../gulp-config/paths');
 const srcPath = paths.toPath('src.assets/js');
 const jsPath = paths.toPath('dist.assets/js');
 const rootPath = paths.toPath('dist.root');
+const { getNotifier } = require('./lib/plugins');
 
 module.exports = (gulp, $, options) => () => {
-    const {isWatching, production, enableNotify } = options;
+    const { production } = options;
     const destPath = production ? jsPath.replace(rootPath, paths.get('tmp')) : jsPath;
+    const { notify, errorHandler } = getNotifier(options);
 
     return gulp.src([`${srcPath}/**/*.js`, `!${srcPath}/**/*.{spec,conf}.js`])
-        .pipe($.plumber({
-            errorHandler: $.notify.onError('Error: <%= error.message %>')
-        }))
+        .pipe($.plumber({ errorHandler }))
         .pipe($.babel())
         .pipe(gulp.dest(destPath))
-        .pipe($.if(isWatching && enableNotify, $.notify({ message: 'Scripts Compiled', onLast: true })))
+        .pipe(notify({ message: 'Scripts Compiled', onLast: true }))
         .pipe($.size({ title: 'scripts' }));
 
 };

--- a/build/gulp-tasks/views.js
+++ b/build/gulp-tasks/views.js
@@ -12,14 +12,14 @@ module.exports = (gulp, $, options) => {
     const _ = require('lodash');
     const glob = require('globby');
     const through = require('through2');
-    const { map } = require('./lib/plugins');
+    const { map, getNotifier } = require('./lib/plugins');
     const rendererCreator = require('./lib/renderers');
 
     const baseData = {};
     const paths = require('../gulp-config/paths');
     const viewPath = paths.toAbsPath('src.views');
     const fixturesPath = paths.toAbsPath('src.fixtures');
-    const { production, banners, viewmatch, isWatching, enableNotify } = options;
+    const { production, banners, viewmatch } = options;
 
     let useRef = () => through.obj();
 
@@ -70,6 +70,7 @@ module.exports = (gulp, $, options) => {
     return () => {
 
         const htmlFilter = $.filter(`**/${viewmatch}`, { restore: true });
+        const { notify, errorHandler } = getNotifier(options);
 
         const data = glob.sync('{,*/}*.json', { cwd: fixturesPath }).reduce((obj, filename) => {
             const id = _.camelCase(filename.toLowerCase().replace('.json', ''));
@@ -78,9 +79,7 @@ module.exports = (gulp, $, options) => {
         }, {});
 
         return gulp.src([`${viewPath}/{,*/}${viewmatch}`, `!${viewPath}/{,*/}_*.*`])
-            .pipe($.plumber({
-                errorHandler: $.notify.onError('Error: <%= error.message %>')
-            }))
+            .pipe($.plumber({ errorHandler }))
             .pipe(map((code, filepath) => {
                 const engine = renderer.match(filepath);
                 if (engine) {
@@ -97,6 +96,6 @@ module.exports = (gulp, $, options) => {
             .pipe(htmlFilter.restore)
             .pipe($.if(production, $.rev.manifest(paths.toPath('dist.root/dist.revmap'), { merge: true })))
             .pipe($.if(production, gulp.dest('.')))
-            .pipe($.if(isWatching && enableNotify, $.notify({ message: 'Views rendered', onLast: true })));
+            .pipe(notify({ message: 'Views rendered', onLast: true }));
     };
 };


### PR DESCRIPTION
Closes #23 

There was a lot of duplicated logic to manage notifications.

This PR moves that logic onto a dedicated function and imports it when needed.

I also refactored the reload stream in `styles` task

@kino90 Could you test it on Windows and tell me if it's working properly?